### PR TITLE
Fix for `TS2307`, `check-list-item` and `marks` with empty arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@tiptap/draftjs-to-tiptap",
   "module": "./dist/index.js",
   "type": "module",
+  "types": "dist/index.d.ts",
   "version": "0.1.1",
   "license": "MIT",
   "repository": {

--- a/src/draftConverter.ts
+++ b/src/draftConverter.ts
@@ -229,7 +229,7 @@ export class DraftConverter {
     }
 
     return result.map(({ text, ranges }) => {
-      const textNode = createText(text);
+      const textNode = createText(text)!;
 
       ranges.forEach((range) =>
         addMark(

--- a/src/draftConverter.ts
+++ b/src/draftConverter.ts
@@ -21,8 +21,8 @@ import {
   isInlineStyleRange,
   type DocumentType,
   type MarkType,
-  type NodeType,
   type TextType,
+  type NodeMapping,
 } from "./utils";
 import {
   mapBlockToNode,
@@ -122,7 +122,7 @@ export class DraftConverter {
   }
 
   mapBlockToNode: MapBlockToNodeFn = (options) => {
-    let didConsume: null | NodeType = null;
+    let didConsume: NodeMapping["block"] | true | null = null;
     try {
       didConsume = this.options.mapBlockToNode.call(this, options) ?? null;
     } catch (e) {

--- a/src/mappings/blockToNode.ts
+++ b/src/mappings/blockToNode.ts
@@ -239,9 +239,7 @@ export const blockToNodeMapping: Record<string, MapBlockToNodeFn> = {
     return addChild(paragraph, entities);
   },
   "code-block"({ block }) {
-    return createNode("codeBlock", {
-      content: [createText(block.text)],
-    });
+    return addChild(createNode("codeBlock"), createText(block.text));
   },
   blockquote({ doc, block, entityMap, converter }) {
     return createNode("blockquote", {

--- a/src/mappings/blockToNode.ts
+++ b/src/mappings/blockToNode.ts
@@ -57,6 +57,7 @@ const mapToListNode: MapBlockToNodeFn = function ({
   entityMap,
   peek,
   next,
+  peekPrev,
   converter,
 }) {
   // Find outer list and listItem node types
@@ -70,7 +71,14 @@ const mapToListNode: MapBlockToNodeFn = function ({
     const currentBlock = getCurrentBlock();
     const { listNodeType: innerListNodeType } = getListNodeType(currentBlock.type)
     let depth = 0;
-    while (depth < currentBlock.depth) {
+
+    const prevBlock = peekPrev();
+    const prevBlockDepth = prevBlock && ["unordered-list-item", "ordered-list-item", "checkable-list-item"].includes(prevBlock.type)
+        ? prevBlock.depth
+        : -1;
+    const currentBlockDepth = currentBlock.depth > prevBlockDepth ? prevBlockDepth + 1 : currentBlock.depth;
+
+    while (depth < currentBlockDepth) {
       if (!listNode.content?.length) {
         listNode.content = [];
       }

--- a/src/mappings/blockToNode.ts
+++ b/src/mappings/blockToNode.ts
@@ -3,6 +3,25 @@ import { addChild, createNode, createText, isListNode } from "../utils";
 import type { MapBlockToNodeFn } from "../types";
 
 
+const mapToParagraphNode: MapBlockToNodeFn = function ({ doc, block, entityMap, converter }) {
+  const paragraph = createNode("paragraph");
+  if (block.inlineStyleRanges.length === 0) {
+    if (block.entityRanges.length === 0) {
+      // Plain text, fast path
+      return addChild(paragraph, createText(block.text));
+    }
+  }
+
+  return addChild(
+      paragraph,
+      converter.splitTextByEntityRangesAndInlineStyleRanges({
+        doc,
+        block,
+        entityMap,
+      })
+  );
+};
+
 type ListNodeNames =
     { listNodeType: "taskList", listItemNodeType: "taskItem" } |
     { listNodeType: "bulletList" | "orderedList", listItemNodeType: "listItem" };
@@ -237,24 +256,9 @@ export const blockToNodeMapping: Record<string, MapBlockToNodeFn> = {
       ],
     });
   },
-  unstyled({ doc, block, entityMap, converter }) {
-    const paragraph = createNode("paragraph");
-    if (block.inlineStyleRanges.length === 0) {
-      if (block.entityRanges.length === 0) {
-        // Plain text, fast path
-        return addChild(paragraph, createText(block.text));
-      }
-    }
-
-    return addChild(
-      paragraph,
-      converter.splitTextByEntityRangesAndInlineStyleRanges({
-        doc,
-        block,
-        entityMap,
-      })
-    );
-  },
+  unstyled: mapToParagraphNode,
+  section: mapToParagraphNode,
+  article: mapToParagraphNode,
   "unordered-list-item": mapToListNode,
   "ordered-list-item": mapToListNode,
   "checkable-list-item": mapToListNode,

--- a/src/mappings/entityToNode.ts
+++ b/src/mappings/entityToNode.ts
@@ -1,6 +1,6 @@
 import type { RawDraftEntity } from "draft-js";
 
-import { type NodeType, createNode } from "../utils";
+import { createNode } from "../utils";
 import type { DraftConverter } from "../draftConverter";
 import type { MapEntityToNodeFn } from "../types";
 
@@ -9,7 +9,7 @@ export const entityToNodeMapping: Record<
   (context: {
     entity: RawDraftEntity;
     converter: DraftConverter;
-  }) => NodeType | null
+  }) => ReturnType<MapEntityToNodeFn>
 > = {
   HORIZONTAL_RULE: () => {
     return createNode("horizontalRule");

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type {
 } from "draft-js";
 
 import type { DraftConverter } from "./draftConverter";
-import type { DocumentType, MarkType, NodeType } from "./utils";
+import type { DocumentType, MarkType, NodeMapping } from './utils';
 
 /**
  * A function that maps a Draft.js block to a ProseMirror node.
@@ -65,7 +65,7 @@ export type MapBlockToNodeFn = (context: {
    * @returns The previous block or null if there is no previous block.
    */
   prev: () => RawDraftContentBlock | null;
-}) => NodeType | null | void | undefined;
+}) => NodeMapping["block"] | true | null | undefined;
 
 /**
  * A function that maps a Draft.js inline style to a ProseMirror mark.
@@ -87,7 +87,7 @@ export type MapInlineStyleToMarkFn = (context: {
    * The current block being converted.
    */
   block: RawDraftContentBlock;
-}) => MarkType | null | void | undefined;
+}) => MarkType | null | undefined;
 
 /**
  * A function that maps a Draft.js entity to a ProseMirror mark.
@@ -113,7 +113,7 @@ export type MapEntityToMarkFn = (context: {
    * The current block being converted.
    */
   block: RawDraftContentBlock;
-}) => MarkType | null | void | undefined;
+}) => MarkType | null | undefined;
 
 /**
  * A function that maps a Draft.js entity to a ProseMirror node.
@@ -139,4 +139,4 @@ export type MapEntityToNodeFn = (context: {
    * The current block being converted.
    */
   block: RawDraftContentBlock;
-}) => NodeType | null | void | undefined;
+}) => NodeMapping["block"] | null | undefined;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -80,6 +80,11 @@ describe("utils.createText", () => {
       marks: [{ type: "bold" }],
     });
   });
+
+  test("should not create a text node without", () => {
+    const text = utils.createText("", [{ type: "bold" }]);
+    expect(text).toEqual(null);
+  });
 });
 
 describe("utils.addMark", () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -35,7 +35,7 @@ describe("utils.addChild", () => {
   });
 
   test("should add child to a node with content", () => {
-    const node = utils.createNode("paragraph", { content: [] });
+    const node = utils.createNode("paragraph");
     const child = utils.createText("Hello");
     utils.addChild(node, child);
     expect(node).toEqual({
@@ -45,9 +45,9 @@ describe("utils.addChild", () => {
   });
 
   test("should add multiple children to a node with content", () => {
-    const node = utils.createNode("paragraph", { content: [] });
-    const child = utils.createText("Hello");
-    const anotherChild = utils.createText("World");
+    const node = utils.createNode("paragraph");
+    const child = utils.createText("Hello")!;
+    const anotherChild = utils.createText("World")!;
     utils.addChild(node, [child, anotherChild]);
     expect(node).toEqual({
       type: "paragraph",

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -30,7 +30,7 @@ describe("utils.addChild", () => {
     utils.addChild(node, child);
     expect(node).toEqual({
       type: "paragraph",
-      content: [{ type: "text", text: "Hello", marks: [] }],
+      content: [{ type: "text", text: "Hello" }],
     });
   });
 
@@ -40,7 +40,7 @@ describe("utils.addChild", () => {
     utils.addChild(node, child);
     expect(node).toEqual({
       type: "paragraph",
-      content: [{ type: "text", text: "Hello", marks: [] }],
+      content: [{ type: "text", text: "Hello" }],
     });
   });
 
@@ -52,8 +52,8 @@ describe("utils.addChild", () => {
     expect(node).toEqual({
       type: "paragraph",
       content: [
-        { type: "text", text: "Hello", marks: [] },
-        { type: "text", text: "World", marks: [] },
+        { type: "text", text: "Hello" },
+        { type: "text", text: "World" },
       ],
     });
   });
@@ -69,7 +69,7 @@ describe("utils.createDocument", () => {
 describe("utils.createText", () => {
   test("should create a text node", () => {
     const text = utils.createText("Hello");
-    expect(text).toEqual({ type: "text", text: "Hello", marks: [] });
+    expect(text).toEqual({ type: "text", text: "Hello" });
   });
 
   test("should create a text node with marks", () => {

--- a/src/utils/pm.ts
+++ b/src/utils/pm.ts
@@ -232,8 +232,10 @@ export function createDocument(): DocumentType {
  * @param marks The marks to apply to the text node.
  * @returns The text node.
  */
-export function createText(text: string, marks?: MarkType[]): TextType {
-  return { type: "text", text, ...marks ? { marks: marks } : {} };
+export function createText(text: string, marks?: MarkType[]): TextType | null {
+  if (!text) return null;
+
+  return { type: "text", text, ...marks && { marks } };
 }
 
 /**

--- a/src/utils/pm.ts
+++ b/src/utils/pm.ts
@@ -81,6 +81,20 @@ export interface NodeMapping {
     MarkType,
     NodeMapping["tableRow"][]
   >;
+  taskItem: NodeType<
+      "taskItem",
+      {
+        checked?: boolean;
+      },
+      MarkType,
+      (NodeType<"taskList"> | NodeType<"paragraph">)[]
+  >;
+  taskList: NodeType<
+      "taskList",
+      Record<string, any>,
+      MarkType,
+      NodeMapping["taskItem"][]
+  >;
   // Custom node types that are not real yet
   pageBreak: NodeType<"pageBreak">;
 }
@@ -269,9 +283,9 @@ export function isNode(node: unknown): node is NodeType {
  */
 export function isListNode(
   node: NodeType | null | undefined
-): node is NodeMapping["bulletList"] | NodeMapping["orderedList"] {
+): node is NodeMapping["bulletList"] | NodeMapping["orderedList"] | NodeMapping["taskList"] {
   return Boolean(
-    node && (node.type === "bulletList" || node.type === "orderedList")
+    node && (node.type === "bulletList" || node.type === "orderedList" || node.type === "taskList")
   );
 }
 

--- a/src/utils/pm.ts
+++ b/src/utils/pm.ts
@@ -113,7 +113,7 @@ export type DocumentType<
 export type TextType<TMarkType extends MarkType = MarkType> = {
   type: "text";
   text: string;
-  marks: TMarkType[];
+  marks?: TMarkType[];
 };
 
 /**
@@ -219,7 +219,7 @@ export function createDocument(): DocumentType {
  * @returns The text node.
  */
 export function createText(text: string, marks?: MarkType[]): TextType {
-  return { type: "text", text, marks: marks || [] };
+  return { type: "text", text, ...marks ? { marks: marks } : {} };
 }
 
 /**

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -532,6 +532,231 @@ exports[`draft-checkable-list 1`] = `
 }
 `;
 
+exports[`draft-input 1`] = `
+{
+  "content": [
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+          ],
+          "text": "jkfl",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+            {
+              "type": "italic",
+            },
+          ],
+          "text": "jkd",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+          ],
+          "text": "bfdjklf",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "text": "ifjkdl",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "type": "italic",
+            },
+          ],
+          "text": "kfjdskl",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+            {
+              "type": "italic",
+            },
+          ],
+          "text": "ABC",
+          "type": "text",
+        },
+        {
+          "marks": [
+            {
+              "type": "italic",
+            },
+          ],
+          "text": "1",
+          "type": "text",
+        },
+        {
+          "marks": [
+            {
+              "type": "italic",
+            },
+            {
+              "type": "bold",
+            },
+          ],
+          "text": "2",
+          "type": "text",
+        },
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+          ],
+          "text": "3",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "text": "Wow, this editor instance exports its content as JSON.",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "ok",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "abc",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "type": "bulletList",
+    },
+    {
+      "content": [
+        {
+          "text": "Wow, this editor instance exports its content as JSON.",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "text": "Wow, this function converts "section" to "unstyled"",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "text": "Wow, this function converts "article" to "unstyled"",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "ok",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "abc",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "type": "bulletList",
+    },
+  ],
+  "type": "doc",
+}
+`;
+
 exports[`draft-axios 1`] = `
 {
   "content": [

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -55,6 +55,87 @@ exports[`draft-list-simple 1`] = `
 }
 `;
 
+exports[`draft-checkable-list-simple 1`] = `
+{
+  "content": [
+    {
+      "content": [
+        {
+          "attrs": {
+            "checked": true,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "taskItem",
+        },
+        {
+          "attrs": {
+            "checked": false,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Check 2 Not checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "taskItem",
+        },
+        {
+          "attrs": {
+            "checked": false,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Check 3 Not checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "taskItem",
+        },
+        {
+          "attrs": {
+            "checked": true,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Check 4 Checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "taskItem",
+        },
+      ],
+      "type": "taskList",
+    },
+  ],
+  "type": "doc",
+}
+`;
+
 exports[`draft-list 1`] = `
 {
   "content": [
@@ -232,6 +313,219 @@ exports[`draft-list 1`] = `
         },
       ],
       "type": "bulletList",
+    },
+  ],
+  "type": "doc",
+}
+`;
+
+exports[`draft-checkable-list 1`] = `
+{
+  "content": [
+    {
+      "content": [
+        {
+          "attrs": {
+            "checked": false,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+            {
+              "content": [
+                {
+                  "attrs": {
+                    "checked": true,
+                  },
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Level 2 Checked",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "content": [
+                        {
+                          "attrs": {
+                            "checked": false,
+                          },
+                          "content": [
+                            {
+                              "content": [
+                                {
+                                  "text": "Level 3",
+                                  "type": "text",
+                                },
+                              ],
+                              "type": "paragraph",
+                            },
+                            {
+                              "content": [
+                                {
+                                  "attrs": {
+                                    "checked": true,
+                                  },
+                                  "content": [
+                                    {
+                                      "content": [
+                                        {
+                                          "text": "Level 4 Checked",
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "type": "paragraph",
+                                    },
+                                  ],
+                                  "type": "taskItem",
+                                },
+                              ],
+                              "type": "taskList",
+                            },
+                          ],
+                          "type": "taskItem",
+                        },
+                      ],
+                      "type": "taskList",
+                    },
+                  ],
+                  "type": "taskItem",
+                },
+                {
+                  "attrs": {
+                    "checked": false,
+                  },
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Level 2 Again",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "content": [
+                        {
+                          "attrs": {
+                            "checked": true,
+                          },
+                          "content": [
+                            {
+                              "content": [
+                                {
+                                  "text": "Level 3 Again Checked",
+                                  "type": "text",
+                                },
+                              ],
+                              "type": "paragraph",
+                            },
+                          ],
+                          "type": "taskItem",
+                        },
+                      ],
+                      "type": "taskList",
+                    },
+                  ],
+                  "type": "taskItem",
+                },
+              ],
+              "type": "taskList",
+            },
+          ],
+          "type": "taskItem",
+        },
+        {
+          "attrs": {
+            "checked": true,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Again Checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+            {
+              "content": [
+                {
+                  "attrs": {
+                    "checked": false,
+                  },
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Level 4 Again",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "taskItem",
+                },
+              ],
+              "type": "taskList",
+            },
+          ],
+          "type": "taskItem",
+        },
+        {
+          "attrs": {
+            "checked": true,
+          },
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Level 1 Again Checked",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+            {
+              "content": [
+                {
+                  "attrs": {
+                    "checked": false,
+                  },
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Level 2 Again",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "taskItem",
+                },
+              ],
+              "type": "taskList",
+            },
+          ],
+          "type": "taskItem",
+        },
+      ],
+      "type": "taskList",
     },
   ],
   "type": "doc",

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -1717,12 +1717,7 @@ exports[`draft-drafttail 1`] = `
       "type": "paragraph",
     },
     {
-      "content": [
-        {
-          "type": "horizontalRule",
-        },
-      ],
-      "type": "paragraph",
+      "type": "horizontalRule",
     },
     {
       "content": [
@@ -1756,16 +1751,11 @@ break"
       "type": "paragraph",
     },
     {
-      "content": [
-        {
-          "attrs": {
-            "alt": "",
-            "src": "https://publish-01.obsidian.md/access/64fc2564d66746d9e19f2f34c7e03326/blog/assets/Logo.png",
-          },
-          "type": "image",
-        },
-      ],
-      "type": "paragraph",
+      "attrs": {
+        "alt": "",
+        "src": "https://publish-01.obsidian.md/access/64fc2564d66746d9e19f2f34c7e03326/blog/assets/Logo.png",
+      },
+      "type": "image",
     },
     {
       "content": [
@@ -3432,6 +3422,94 @@ exports[`draft-deep-list 1`] = `
               "content": [
                 {
                   "text": "depth 0 -> 0",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "type": "orderedList",
+    },
+  ],
+  "type": "doc",
+}
+`;
+
+exports[`draft-nested-list 1`] = `
+{
+  "content": [
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Point 1",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Nested Bullet 1",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+                {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Nested Bullet 2",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+                {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Nested Bullet 3",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+              ],
+              "type": "bulletList",
+            },
+          ],
+          "type": "listItem",
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Point 2",
                   "type": "text",
                 },
               ],

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`draft-list-simple 1`] = `
 {
@@ -10,7 +10,6 @@ exports[`draft-list-simple 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1",
                   "type": "text",
                 },
@@ -25,7 +24,6 @@ exports[`draft-list-simple 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1 bullet 2",
                   "type": "text",
                 },
@@ -40,7 +38,6 @@ exports[`draft-list-simple 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1 bullet 3",
                   "type": "text",
                 },
@@ -68,7 +65,6 @@ exports[`draft-list 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1",
                   "type": "text",
                 },
@@ -82,7 +78,6 @@ exports[`draft-list 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "Level 2",
                           "type": "text",
                         },
@@ -96,7 +91,6 @@ exports[`draft-list 1`] = `
                             {
                               "content": [
                                 {
-                                  "marks": [],
                                   "text": "Level 3",
                                   "type": "text",
                                 },
@@ -110,7 +104,6 @@ exports[`draft-list 1`] = `
                                     {
                                       "content": [
                                         {
-                                          "marks": [],
                                           "text": "Level 4",
                                           "type": "text",
                                         },
@@ -137,7 +130,6 @@ exports[`draft-list 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "Level 2 Again",
                           "type": "text",
                         },
@@ -151,7 +143,6 @@ exports[`draft-list 1`] = `
                             {
                               "content": [
                                 {
-                                  "marks": [],
                                   "text": "Level 3 Again",
                                   "type": "text",
                                 },
@@ -178,7 +169,6 @@ exports[`draft-list 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1 Again",
                   "type": "text",
                 },
@@ -192,7 +182,6 @@ exports[`draft-list 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "Level 4 Again",
                           "type": "text",
                         },
@@ -213,7 +202,6 @@ exports[`draft-list 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Level 1 Again",
                   "type": "text",
                 },
@@ -227,7 +215,6 @@ exports[`draft-list 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "Level 2 Again",
                           "type": "text",
                         },
@@ -257,7 +244,6 @@ exports[`draft-axios 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "The merger of generative AI and robotics is likely to ",
           "type": "text",
         },
@@ -275,7 +261,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": ", but one of the earliest — and cutest — is a chatty, 14-inch-tall kids' companion named Moxie.",
           "type": "text",
         },
@@ -294,7 +279,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " The large language models that power chatbots like ChatGPT open the door to a new generation of conversational robots that aren't constrained by a set of predetermined scripts and commands, a prospect that is both tantalizing and terrifying. ",
           "type": "text",
         },
@@ -313,7 +297,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": "18 months into life with ChatGPT, more and more companies are building physical robots with generative AI capabilities. ",
           "type": "text",
         },
@@ -327,7 +310,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "OpenAI itself is reviving the robotics unit it disbanded in 2020, ",
                   "type": "text",
                 },
@@ -345,7 +327,6 @@ exports[`draft-axios 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ".",
                   "type": "text",
                 },
@@ -370,7 +351,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -388,7 +368,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " is designed for kids ages 5 to 10, and offers a range of games and activities as well as the ability to have open-ended conversations.",
           "type": "text",
         },
@@ -402,7 +381,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Initially, Moxie takes its child pal through a series of missions designed to help them get to know the robot and its capabilities — and to help Moxie get to know its human. The backstory is that Moxie is fresh from the robot factory and looking to make friends and better understand the human world. ",
                   "type": "text",
                 },
@@ -417,7 +395,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Unlike ",
                   "type": "text",
                 },
@@ -435,7 +412,6 @@ exports[`draft-axios 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ", Moxie has a wide repertoire of skills. It can tell jokes, serve up brain teasers, play games like Simon Says or "guess that animal," send kids on a scavenger hunt, pose for selfies or just talk with kids about their interests and emotions. Moxie can tell stories about a topic, listen as a kid tells it a story or watch as a child draws.",
                   "type": "text",
                 },
@@ -450,7 +426,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Moxie moves its arms, pivots and displays big eyes and a range of facial expressions and inflections on the curved computer screen that serves as its face. Moxie doesn't have wheels or legs, meaning it can fit into a small space (although instructions say to give it a few feet of space from a wall). Moxie can operate either plugged in or running on its rechargeable battery.",
                   "type": "text",
                 },
@@ -465,7 +440,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Under the hood, Moxie uses speech recognition to understand what a kid is saying, face recognition to help detect emotion and a mix of guided conversation and large language models to carry on a conversation.",
                   "type": "text",
                 },
@@ -490,7 +464,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " Moxie's creators say video recording is used to recognize the user's face and detect emotion, and the raw videos never leave the device. Recorded audio goes to the cloud for processing and transcripts of the conversations do get sent back to Embodied, the company behind Moxie. ",
           "type": "text",
         },
@@ -504,7 +477,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Embodied says it takes steps to de-identify and encrypt the data, and uses most of the data in aggregate to get a sense of how kids are spending their time with Moxie. Still, depending on what a kid shares, a fair bit of personal information could be finding its way back to the company, even if the company doesn't use it.",
                   "type": "text",
                 },
@@ -519,7 +491,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "A companion phone app shows parents how long their kids spent with Moxie each day and which activities they did, but not a transcript of what was said.",
                   "type": "text",
                 },
@@ -544,7 +515,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " I spent about a week testing Moxie, along with my 11-year-old son Harvey. ",
           "type": "text",
         },
@@ -558,7 +528,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "The highlights were the many times that it was clear that Moxie not only heard and understood Harvey, but was able to show it knew more about the topic. ",
                   "type": "text",
                 },
@@ -573,7 +542,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "When Harvey said his favorite soccer player was "Messi," Moxie knew he meant Argentinian star Lionel Messi. ",
                   "type": "text",
                 },
@@ -588,7 +556,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "On Monday, Moxie knew it was Memorial Day, and asked how Harvey spent the day.",
                   "type": "text",
                 },
@@ -603,7 +570,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "As is the case with his non-robot companions, Harvey's favorite thing to do with Moxie was play games. One of his favorite games was of his own creation — putting a folder on Moxie's head and seeing how long it would take to fall off during their play together.",
                   "type": "text",
                 },
@@ -628,7 +594,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " for Harvey was when Moxie would mispronounce something or repeat itself. Every time that happened, it seemed to break the emotional connection, and it would be a minute or two before Harvey fully re-engaged.",
           "type": "text",
         },
@@ -642,7 +607,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Moxie is also a bit heavy-handed in the early conversations, rigidly sticking to its planned activities. That's helpful to make sure kids know how the robot works, but it can try a kid's patience when they just want to start having fun.",
                   "type": "text",
                 },
@@ -657,7 +621,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Moxie's creators tell me that adding flexibility and reducing the times that Moxie makes mistakes are both areas they're actively working to improve.",
                   "type": "text",
                 },
@@ -682,7 +645,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " Moxie is just the beginning in what is sure to be a wave of conversational robots. I can easily see similar devices targeted at a range of populations, including housebound seniors and others who are dealing with loneliness.",
           "type": "text",
         },
@@ -696,7 +658,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "There are some big questions, from what values guide the robot to what data is collected. ",
                   "type": "text",
                 },
@@ -721,7 +682,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " Large language models offer the opportunity for robots to go beyond any sort of script. This is what makes them surprisingly powerful, but also what makes me hesitant as a parent to leave my kid alone with one.",
           "type": "text",
         },
@@ -735,7 +695,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "In my testing, Moxie said all the right things. There was nothing I disagreed with as a parent or even found controversial. Moxie was supportive, encouraging and a good listener.",
                   "type": "text",
                 },
@@ -750,7 +709,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Moxie is willing and eager to talk about hard feelings and emotions but gently defers discussion of sensitive topics, directing kids to talk to a trusted adult.",
                   "type": "text",
                 },
@@ -765,7 +723,6 @@ exports[`draft-axios 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "After several days, I found myself less hesitant about leaving Harvey and Moxie alone, an experience I'm told is not uncommon. Some parents become more comfortable over time and others choose to remain within earshot.",
                   "type": "text",
                 },
@@ -790,7 +747,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " At $799 from both Amazon and Moxie's website, the robot isn't cheap. For now there is no subscription fee, but the company is working on an expanded set of educational content that will be offered as a paid subscription.",
           "type": "text",
         },
@@ -809,7 +765,6 @@ exports[`draft-axios 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": ": Moxie's creators are working on a "pro" version of the robot that could be used in schools, hospitals and other group settings.",
           "type": "text",
         },
@@ -827,7 +782,6 @@ exports[`draft-drafttail 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "Unstyled ",
           "type": "text",
         },
@@ -841,7 +795,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -855,7 +808,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -869,7 +821,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -883,7 +834,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -897,67 +847,54 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Mark",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Quotation",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Small",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Sample",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Insert",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
         {
-          "marks": [],
           "text": "Delete",
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -971,7 +908,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -985,7 +921,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -999,7 +934,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -1017,7 +951,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -1034,7 +967,6 @@ exports[`draft-drafttail 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " ",
           "type": "text",
         },
@@ -1063,7 +995,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header one",
           "type": "text",
         },
@@ -1076,7 +1007,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header two",
           "type": "text",
         },
@@ -1089,7 +1019,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header three",
           "type": "text",
         },
@@ -1102,7 +1031,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header four",
           "type": "text",
         },
@@ -1115,7 +1043,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header five",
           "type": "text",
         },
@@ -1128,7 +1055,6 @@ exports[`draft-drafttail 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Header six",
           "type": "text",
         },
@@ -1142,7 +1068,6 @@ exports[`draft-drafttail 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Unordered list item",
                   "type": "text",
                 },
@@ -1156,7 +1081,6 @@ exports[`draft-drafttail 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "ffgdfg",
                           "type": "text",
                         },
@@ -1182,7 +1106,6 @@ exports[`draft-drafttail 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Ordered list item",
                   "type": "text",
                 },
@@ -1197,7 +1120,6 @@ exports[`draft-drafttail 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "fdfdg",
                   "type": "text",
                 },
@@ -1211,7 +1133,6 @@ exports[`draft-drafttail 1`] = `
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "dfdgd",
                           "type": "text",
                         },
@@ -1232,7 +1153,6 @@ exports[`draft-drafttail 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "DFG",
                   "type": "text",
                 },
@@ -1250,7 +1170,6 @@ exports[`draft-drafttail 1`] = `
         {
           "content": [
             {
-              "marks": [],
               "text": "Blockquote",
               "type": "text",
             },
@@ -1263,7 +1182,6 @@ exports[`draft-drafttail 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "Code",
           "type": "text",
         },
@@ -1273,7 +1191,6 @@ exports[`draft-drafttail 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "Horizontal rule",
           "type": "text",
         },
@@ -1295,7 +1212,6 @@ exports[`draft-drafttail 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": 
 "Soft line
 break"
@@ -1314,7 +1230,6 @@ break"
     {
       "content": [
         {
-          "marks": [],
           "text": "Image",
           "type": "text",
         },
@@ -1340,7 +1255,6 @@ break"
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "0",
                   "type": "text",
                 },
@@ -1354,7 +1268,6 @@ break"
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "1",
                           "type": "text",
                         },
@@ -1368,7 +1281,6 @@ break"
                             {
                               "content": [
                                 {
-                                  "marks": [],
                                   "text": "2",
                                   "type": "text",
                                 },
@@ -1382,7 +1294,6 @@ break"
                                     {
                                       "content": [
                                         {
-                                          "marks": [],
                                           "text": "3",
                                           "type": "text",
                                         },
@@ -1396,7 +1307,6 @@ break"
                                             {
                                               "content": [
                                                 {
-                                                  "marks": [],
                                                   "text": "4",
                                                   "type": "text",
                                                 },
@@ -1410,7 +1320,6 @@ break"
                                                     {
                                                       "content": [
                                                         {
-                                                          "marks": [],
                                                           "text": "5",
                                                           "type": "text",
                                                         },
@@ -1423,11 +1332,10 @@ break"
                                                           "content": [
                                                             {
                                                               "content": [
-{
-"marks": [],
-"text": "6",
-"type": "text",
-},
+                                                                {
+                                                                "text": "6",
+                                                                "type": "text",
+                                                                },
                                                               ],
                                                               "type": "paragraph",
                                                             },
@@ -1438,11 +1346,10 @@ break"
                                                           "content": [
                                                             {
                                                               "content": [
-{
-"marks": [],
-"text": "7",
-"type": "text",
-},
+                                                                {
+                                                                "text": "7",
+                                                                "type": "text",
+                                                                },
                                                               ],
                                                               "type": "paragraph",
                                                             },
@@ -1495,7 +1402,6 @@ break"
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "0",
                   "type": "text",
                 },
@@ -1509,7 +1415,6 @@ break"
                     {
                       "content": [
                         {
-                          "marks": [],
                           "text": "1",
                           "type": "text",
                         },
@@ -1523,7 +1428,6 @@ break"
                             {
                               "content": [
                                 {
-                                  "marks": [],
                                   "text": "2",
                                   "type": "text",
                                 },
@@ -1537,7 +1441,6 @@ break"
                                     {
                                       "content": [
                                         {
-                                          "marks": [],
                                           "text": "3",
                                           "type": "text",
                                         },
@@ -1551,7 +1454,6 @@ break"
                                             {
                                               "content": [
                                                 {
-                                                  "marks": [],
                                                   "text": "4",
                                                   "type": "text",
                                                 },
@@ -1565,7 +1467,6 @@ break"
                                                     {
                                                       "content": [
                                                         {
-                                                          "marks": [],
                                                           "text": "5",
                                                           "type": "text",
                                                         },
@@ -1578,11 +1479,10 @@ break"
                                                           "content": [
                                                             {
                                                               "content": [
-{
-"marks": [],
-"text": "6",
-"type": "text",
-},
+                                                                {
+                                                                "text": "6",
+                                                                "type": "text",
+                                                                },
                                                               ],
                                                               "type": "paragraph",
                                                             },
@@ -1593,11 +1493,10 @@ break"
                                                           "content": [
                                                             {
                                                               "content": [
-{
-"marks": [],
-"text": "7",
-"type": "text",
-},
+                                                                {
+                                                                "text": "7",
+                                                                "type": "text",
+                                                                },
                                                               ],
                                                               "type": "paragraph",
                                                             },
@@ -1646,7 +1545,6 @@ break"
     {
       "content": [
         {
-          "marks": [],
           "text": "End",
           "type": "text",
         },
@@ -1664,7 +1562,6 @@ exports[`draft-table-drafttail 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "",
           "type": "text",
         },
@@ -1680,7 +1577,6 @@ exports[`draft-table-drafttail 1`] = `
                 {
                   "content": [
                     {
-                      "marks": [],
                       "text": "Hello, ",
                       "type": "text",
                     },
@@ -1694,7 +1590,6 @@ exports[`draft-table-drafttail 1`] = `
                       "type": "text",
                     },
                     {
-                      "marks": [],
                       "text": "!",
                       "type": "text",
                     },
@@ -1732,7 +1627,6 @@ exports[`draft-table-drafttail 1`] = `
                 {
                   "content": [
                     {
-                      "marks": [],
                       "text": "This is an example of a table",
                       "type": "text",
                     },
@@ -1761,7 +1655,6 @@ exports[`draft-table-drafttail 1`] = `
                 {
                   "content": [
                     {
-                      "marks": [],
                       "text": "It ",
                       "type": "text",
                     },
@@ -1775,7 +1668,6 @@ exports[`draft-table-drafttail 1`] = `
                       "type": "text",
                     },
                     {
-                      "marks": [],
                       "text": " works",
                       "type": "text",
                     },
@@ -1794,7 +1686,6 @@ exports[`draft-table-drafttail 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "",
           "type": "text",
         },
@@ -1836,7 +1727,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "This page is fully editable.",
           "type": "text",
         },
@@ -1850,7 +1740,6 @@ exports[`draft-medium-complex 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Try to select some text to open the toolbar",
                   "type": "text",
                 },
@@ -1865,7 +1754,6 @@ exports[`draft-medium-complex 1`] = `
             {
               "content": [
                 {
-                  "marks": [],
                   "text": "Goto an empty line to add an image.",
                   "type": "text",
                 },
@@ -1883,7 +1771,6 @@ exports[`draft-medium-complex 1`] = `
         {
           "content": [
             {
-              "marks": [],
               "text": "A medium like rich text editor built using ",
               "type": "text",
             },
@@ -1901,7 +1788,6 @@ exports[`draft-medium-complex 1`] = `
               "type": "text",
             },
             {
-              "marks": [],
               "text": " with an emphasis on eliminating mouse usage by adding relevant keyboard shortcuts.",
               "type": "text",
             },
@@ -1916,7 +1802,6 @@ exports[`draft-medium-complex 1`] = `
         {
           "content": [
             {
-              "marks": [],
               "text": "The keyboard ",
               "type": "text",
             },
@@ -1930,7 +1815,6 @@ exports[`draft-medium-complex 1`] = `
               "type": "text",
             },
             {
-              "marks": [],
               "text": " are ",
               "type": "text",
             },
@@ -1944,7 +1828,6 @@ exports[`draft-medium-complex 1`] = `
               "type": "text",
             },
             {
-              "marks": [],
               "text": " below.",
               "type": "text",
             },
@@ -1957,7 +1840,6 @@ exports[`draft-medium-complex 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "It also has implementations of some custom blocks like",
           "type": "text",
         },
@@ -1970,7 +1852,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Custom Blocks",
           "type": "text",
         },
@@ -1982,7 +1863,6 @@ exports[`draft-medium-complex 1`] = `
         {
           "content": [
             {
-              "marks": [],
               "text": "This is a blockquote.",
               "type": "text",
             },
@@ -1998,7 +1878,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Image Block",
           "type": "text",
         },
@@ -2046,7 +1925,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Embed Block (Using Embedly)",
           "type": "text",
         },
@@ -2059,7 +1937,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Todo Block",
           "type": "text",
         },
@@ -2072,7 +1949,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Keyboard shortcuts",
           "type": "text",
         },
@@ -2082,7 +1958,6 @@ exports[`draft-medium-complex 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "Following are the keyboard shortcuts to toggle block types (",
           "type": "text",
         },
@@ -2096,7 +1971,6 @@ exports[`draft-medium-complex 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " and ",
           "type": "text",
         },
@@ -2110,7 +1984,6 @@ exports[`draft-medium-complex 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " for Windows/Linux and ",
           "type": "text",
         },
@@ -2124,7 +1997,6 @@ exports[`draft-medium-complex 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " and ",
           "type": "text",
         },
@@ -2138,7 +2010,6 @@ exports[`draft-medium-complex 1`] = `
           "type": "text",
         },
         {
-          "marks": [],
           "text": " for OSX.",
           "type": "text",
         },
@@ -2161,7 +2032,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " +",
                   "type": "text",
                 },
@@ -2184,7 +2054,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Toggle ",
                           "type": "text",
                         },
@@ -2198,7 +2067,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": ".",
                           "type": "text",
                         },
@@ -2222,7 +2090,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Toggle ",
                           "type": "text",
                         },
@@ -2236,7 +2103,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": ".",
                           "type": "text",
                         },
@@ -2260,7 +2126,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Add ",
                           "type": "text",
                         },
@@ -2274,7 +2139,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " to selected text.",
                           "type": "text",
                         },
@@ -2298,7 +2162,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Toggle ",
                           "type": "text",
                         },
@@ -2312,7 +2175,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": ".",
                           "type": "text",
                         },
@@ -2336,7 +2198,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Toggle ",
                           "type": "text",
                         },
@@ -2350,7 +2211,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " block.",
                           "type": "text",
                         },
@@ -2374,7 +2234,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - Toggle ",
                           "type": "text",
                         },
@@ -2388,7 +2247,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " block.",
                           "type": "text",
                         },
@@ -2412,7 +2270,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " - ",
                           "type": "text",
                         },
@@ -2426,7 +2283,6 @@ exports[`draft-medium-complex 1`] = `
                           "type": "text",
                         },
                         {
-                          "marks": [],
                           "text": " selection.",
                           "type": "text",
                         },
@@ -2451,7 +2307,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Editor level commands",
           "type": "text",
         },
@@ -2474,7 +2329,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - Save current data to ",
                   "type": "text",
                 },
@@ -2488,7 +2342,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ".",
                   "type": "text",
                 },
@@ -2512,7 +2365,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - Load previously saved data from ",
                   "type": "text",
                 },
@@ -2526,7 +2378,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ".",
                   "type": "text",
                 },
@@ -2542,7 +2393,6 @@ exports[`draft-medium-complex 1`] = `
     {
       "content": [
         {
-          "marks": [],
           "text": "Special characters while typing: If while typing in an empty block, if the content matches one of the following, that particular block type will be changed to the corresponding block specified below -",
           "type": "text",
         },
@@ -2565,7 +2415,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " ",
                   "type": "text",
                 },
@@ -2579,7 +2428,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - If current block is ",
                   "type": "text",
                 },
@@ -2593,7 +2441,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ", it will be changed to ",
                   "type": "text",
                 },
@@ -2607,7 +2454,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ", else ",
                   "type": "text",
                 },
@@ -2621,7 +2467,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ".",
                   "type": "text",
                 },
@@ -2645,7 +2490,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " ",
                   "type": "text",
                 },
@@ -2659,7 +2503,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - ",
                   "type": "text",
                 },
@@ -2692,7 +2535,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " ",
                   "type": "text",
                 },
@@ -2706,7 +2548,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - ",
                   "type": "text",
                 },
@@ -2720,7 +2561,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": ".",
                   "type": "text",
                 },
@@ -2744,7 +2584,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - ",
                   "type": "text",
                 },
@@ -2777,7 +2616,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - ",
                   "type": "text",
                 },
@@ -2810,7 +2648,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": " - ",
                   "type": "text",
                 },
@@ -2843,7 +2680,6 @@ exports[`draft-medium-complex 1`] = `
                   "type": "text",
                 },
                 {
-                  "marks": [],
                   "text": "- ",
                   "type": "text",
                 },
@@ -2871,7 +2707,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Todos",
           "type": "text",
         },
@@ -2884,7 +2719,6 @@ exports[`draft-medium-complex 1`] = `
       },
       "content": [
         {
-          "marks": [],
           "text": "Issue",
           "type": "text",
         },

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -1854,12 +1854,6 @@ exports[`draft-table-drafttail 1`] = `
 {
   "content": [
     {
-      "content": [
-        {
-          "text": "",
-          "type": "text",
-        },
-      ],
       "type": "paragraph",
     },
     {
@@ -1978,12 +1972,6 @@ exports[`draft-table-drafttail 1`] = `
       "type": "table",
     },
     {
-      "content": [
-        {
-          "text": "",
-          "type": "text",
-        },
-      ],
       "type": "paragraph",
     },
   ],

--- a/test/__snapshots__/draft-inputs.test.ts.snap
+++ b/test/__snapshots__/draft-inputs.test.ts.snap
@@ -3236,3 +3236,214 @@ exports[`draft-medium-complex 1`] = `
   "type": "doc",
 }
 `;
+
+exports[`draft-deep-list 1`] = `
+{
+  "content": [
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "depth 5 -> 0",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "depth 1 -> 1",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "content": [
+                        {
+                          "content": [
+                            {
+                              "content": [
+                                {
+                                  "text": "depth 5 -> 2",
+                                  "type": "text",
+                                },
+                              ],
+                              "type": "paragraph",
+                            },
+                            {
+                              "content": [
+                                {
+                                  "content": [
+                                    {
+                                      "content": [
+                                        {
+                                          "text": "depth 3 -> 3",
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "type": "paragraph",
+                                    },
+                                    {
+                                      "content": [
+                                        {
+                                          "content": [
+                                            {
+                                              "content": [
+                                                {
+                                                  "text": "depth 7 -> 4",
+                                                  "type": "text",
+                                                },
+                                              ],
+                                              "type": "paragraph",
+                                            },
+                                          ],
+                                          "type": "listItem",
+                                        },
+                                      ],
+                                      "type": "orderedList",
+                                    },
+                                  ],
+                                  "type": "listItem",
+                                },
+                                {
+                                  "content": [
+                                    {
+                                      "content": [
+                                        {
+                                          "text": "depth 3 -> 3",
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "type": "paragraph",
+                                    },
+                                    {
+                                      "content": [
+                                        {
+                                          "content": [
+                                            {
+                                              "content": [
+                                                {
+                                                  "text": "depth 7 -> 4",
+                                                  "type": "text",
+                                                },
+                                              ],
+                                              "type": "paragraph",
+                                            },
+                                          ],
+                                          "type": "listItem",
+                                        },
+                                      ],
+                                      "type": "orderedList",
+                                    },
+                                  ],
+                                  "type": "listItem",
+                                },
+                                {
+                                  "content": [
+                                    {
+                                      "content": [
+                                        {
+                                          "text": "depth 3 -> 3",
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "type": "paragraph",
+                                    },
+                                  ],
+                                  "type": "listItem",
+                                },
+                              ],
+                              "type": "orderedList",
+                            },
+                          ],
+                          "type": "listItem",
+                        },
+                        {
+                          "content": [
+                            {
+                              "content": [
+                                {
+                                  "text": "depth 2 -> 2",
+                                  "type": "text",
+                                },
+                              ],
+                              "type": "paragraph",
+                            },
+                          ],
+                          "type": "listItem",
+                        },
+                      ],
+                      "type": "orderedList",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+                {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "depth 1 -> 1",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                    {
+                      "content": [
+                        {
+                          "content": [
+                            {
+                              "content": [
+                                {
+                                  "text": "depth 2 -> 2",
+                                  "type": "text",
+                                },
+                              ],
+                              "type": "paragraph",
+                            },
+                          ],
+                          "type": "listItem",
+                        },
+                      ],
+                      "type": "orderedList",
+                    },
+                  ],
+                  "type": "listItem",
+                },
+              ],
+              "type": "orderedList",
+            },
+          ],
+          "type": "listItem",
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "depth 0 -> 0",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "listItem",
+        },
+      ],
+      "type": "orderedList",
+    },
+  ],
+  "type": "doc",
+}
+`;

--- a/test/draft-checkable-list-simple.json
+++ b/test/draft-checkable-list-simple.json
@@ -1,0 +1,45 @@
+{
+    "blocks": [
+        {
+            "key": "cek31",
+            "data": {
+                "checked": true
+            },
+            "text": "Level 1 Checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "7tiu3",
+            "data": {},
+            "text": "Level 1 Check 2 Not checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "eocb8",
+            "data": {},
+            "text": "Level 1 Check 3 Not checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "7qp46",
+            "data": {
+                "checked": true
+            },
+            "text": "Level 1 Check 4 Checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        }
+    ],
+    "entityMap": {}
+}

--- a/test/draft-checkable-list.json
+++ b/test/draft-checkable-list.json
@@ -1,0 +1,105 @@
+{
+    "entityMap": {},
+    "blocks": [
+        {
+            "key": "14ddo",
+            "text": "Level 1",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "59gth",
+            "text": "Level 2 Checked",
+            "type": "checkable-list-item",
+            "depth": 1,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {
+                "checked": true
+            }
+        },
+        {
+            "key": "59bth",
+            "text": "Level 3",
+            "type": "checkable-list-item",
+            "depth": 2,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "24bth",
+            "text": "Level 4 Checked",
+            "type": "checkable-list-item",
+            "depth": 3,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {
+                "checked": true
+            }
+        },
+        {
+            "key": "24cth",
+            "text": "Level 2 Again",
+            "type": "checkable-list-item",
+            "depth": 1,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "24dth",
+            "text": "Level 3 Again Checked",
+            "type": "checkable-list-item",
+            "depth": 2,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {
+                "checked": true
+            }
+        },
+        {
+            "key": "24eth",
+            "text": "Level 1 Again Checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {
+                "checked": true
+            }
+        },
+        {
+            "key": "24fth",
+            "text": "Level 4 Again",
+            "type": "checkable-list-item",
+            "depth": 3,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "24gth",
+            "text": "Level 1 Again Checked",
+            "type": "checkable-list-item",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {
+                "checked": true
+            }
+        },
+        {
+            "key": "24hth",
+            "text": "Level 2 Again",
+            "type": "checkable-list-item",
+            "depth": 1,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        }
+    ]
+}

--- a/test/draft-deep-list.json
+++ b/test/draft-deep-list.json
@@ -1,0 +1,113 @@
+{
+    "blocks": [
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 5 -> 0",
+            "type": "ordered-list-item",
+            "depth": 5,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 1 -> 1",
+            "type": "ordered-list-item",
+            "depth": 1,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 5 -> 2",
+            "type": "ordered-list-item",
+            "depth": 5,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 3 -> 3",
+            "type": "ordered-list-item",
+            "depth": 3,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 7 -> 4",
+            "type": "ordered-list-item",
+            "depth": 7,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 3 -> 3",
+            "type": "ordered-list-item",
+            "depth": 3,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 7 -> 4",
+            "type": "ordered-list-item",
+            "depth": 7,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 3 -> 3",
+            "type": "ordered-list-item",
+            "depth": 3,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 2 -> 2",
+            "type": "ordered-list-item",
+            "depth": 2,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 1 -> 1",
+            "type": "ordered-list-item",
+            "depth": 1,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 2 -> 2",
+            "type": "ordered-list-item",
+            "depth": 2,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "test",
+            "data": {},
+            "text": "depth 0 -> 0",
+            "type": "ordered-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        }
+    ],
+    "entityMap": {}
+}

--- a/test/draft-input.json
+++ b/test/draft-input.json
@@ -137,6 +137,24 @@
       "data": {}
     },
     {
+      "key": "5ro41",
+      "text": "Wow, this function converts \"section\" to \"unstyled\"",
+      "type": "section",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "5ro41",
+      "text": "Wow, this function converts \"article\" to \"unstyled\"",
+      "type": "article",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
       "key": "14ddo",
       "text": "ok",
       "type": "unordered-list-item",

--- a/test/draft-inputs.test.ts
+++ b/test/draft-inputs.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { DraftConverter } from "../src/index";
 import draftListSimple from "./draft-list-simple.json";
 import draftDeepList from "./draft-deep-list.json";
+import draftNestedList from "./draft-nested-list.json";
 import draftCheckableListSimple from "./draft-checkable-list-simple.json";
 import draftList from "./draft-list.json";
 import draftCheckableList from "./draft-checkable-list.json";
@@ -19,6 +20,11 @@ test("draft-list-simple", () => {
 test("draft-deep-list", () => {
   const converter = new DraftConverter();
   expect(converter.convert(draftDeepList)).toMatchSnapshot();
+});
+
+test("draft-nested-list", () => {
+  const converter = new DraftConverter();
+  expect(converter.convert(draftNestedList)).toMatchSnapshot();
 });
 
 test("draft-checkable-list-simple", () => {

--- a/test/draft-inputs.test.ts
+++ b/test/draft-inputs.test.ts
@@ -92,7 +92,6 @@ test("draft-medium-complex", () => {
           {
             type: "text",
             text: "🕺🏽 ",
-            marks: [],
           },
           {
             type: "text",
@@ -106,7 +105,6 @@ test("draft-medium-complex", () => {
           {
             type: "text",
             text: " hosts a jazz second-line through the French Quarter at 3pm, followed by happy hour at Pat O'Brien's. (",
-            marks: [],
           },
           {
             type: "text",
@@ -127,7 +125,6 @@ test("draft-medium-complex", () => {
           {
             type: "text",
             text: ")",
-            marks: [],
           },
         ],
       },

--- a/test/draft-inputs.test.ts
+++ b/test/draft-inputs.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
 import { DraftConverter } from "../src/index";
 import draftListSimple from "./draft-list-simple.json";
+import draftCheckableListSimple from "./draft-checkable-list-simple.json";
 import draftList from "./draft-list.json";
+import draftCheckableList from "./draft-checkable-list.json";
 import draftAxios from "./draft-axios.json";
 import draftTail from "./draft-drafttail.json";
 import draftTailTable from "./draft-table-drafttail.json";
@@ -12,9 +14,19 @@ test("draft-list-simple", () => {
   expect(converter.convert(draftListSimple)).toMatchSnapshot();
 });
 
+test("draft-checkable-list-simple", () => {
+  const converter = new DraftConverter();
+  expect(converter.convert(draftCheckableListSimple)).toMatchSnapshot();
+});
+
 test("draft-list", () => {
   const converter = new DraftConverter();
   expect(converter.convert(draftList)).toMatchSnapshot();
+});
+
+test("draft-checkable-list", () => {
+  const converter = new DraftConverter();
+  expect(converter.convert(draftCheckableList)).toMatchSnapshot();
 });
 
 test("draft-axios", () => {

--- a/test/draft-inputs.test.ts
+++ b/test/draft-inputs.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { DraftConverter } from "../src/index";
 import draftListSimple from "./draft-list-simple.json";
+import draftDeepList from "./draft-deep-list.json";
 import draftCheckableListSimple from "./draft-checkable-list-simple.json";
 import draftList from "./draft-list.json";
 import draftCheckableList from "./draft-checkable-list.json";
@@ -13,6 +14,11 @@ import draftMediumComplex from "./draft-medium-complex.json";
 test("draft-list-simple", () => {
   const converter = new DraftConverter();
   expect(converter.convert(draftListSimple)).toMatchSnapshot();
+});
+
+test("draft-deep-list", () => {
+  const converter = new DraftConverter();
+  expect(converter.convert(draftDeepList)).toMatchSnapshot();
 });
 
 test("draft-checkable-list-simple", () => {

--- a/test/draft-inputs.test.ts
+++ b/test/draft-inputs.test.ts
@@ -4,6 +4,7 @@ import draftListSimple from "./draft-list-simple.json";
 import draftCheckableListSimple from "./draft-checkable-list-simple.json";
 import draftList from "./draft-list.json";
 import draftCheckableList from "./draft-checkable-list.json";
+import draftInput from "./draft-input.json";
 import draftAxios from "./draft-axios.json";
 import draftTail from "./draft-drafttail.json";
 import draftTailTable from "./draft-table-drafttail.json";
@@ -27,6 +28,11 @@ test("draft-list", () => {
 test("draft-checkable-list", () => {
   const converter = new DraftConverter();
   expect(converter.convert(draftCheckableList)).toMatchSnapshot();
+});
+
+test("draft-input", () => {
+  const converter = new DraftConverter();
+  expect(converter.convert(draftInput as any)).toMatchSnapshot();
 });
 
 test("draft-axios", () => {

--- a/test/draft-nested-list.json
+++ b/test/draft-nested-list.json
@@ -1,0 +1,50 @@
+{
+    "blocks": [
+        {
+            "key": "fs1eu",
+            "data": {},
+            "text": "Point 1",
+            "type": "ordered-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "1ttv0",
+            "data": {},
+            "text": "Nested Bullet 1",
+            "type": "unordered-list-item",
+            "depth": 1,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "e5oim",
+            "data": {},
+            "text": "Nested Bullet 2",
+            "type": "unordered-list-item",
+            "depth": 1,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "39tfs",
+            "data": {},
+            "text": "Nested Bullet 3",
+            "type": "unordered-list-item",
+            "depth": 1,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        },
+        {
+            "key": "b1k48",
+            "data": {},
+            "text": "Point 2",
+            "type": "ordered-list-item",
+            "depth": 0,
+            "entityRanges": [],
+            "inlineStyleRanges": []
+        }
+    ],
+    "entityMap": {}
+}


### PR DESCRIPTION
This PR provides changes for things mentioned in this issue https://github.com/ueberdosis/draft-js-to-tiptap/issues/18

In addition:
 - fixed issue with `Invalid content` in editor which is caused by having nodes of type `"text"` with empty text: `{ "type": "text", "text": "" }`
 - added support for `section` and `article` DraftJs block types which are mapped to `paragraph` nodes
 -  fixed issue with `Invalid content` in editor which is caused by having nodes of type `"text"` with empty text: `{ "type": "text", "text": "" }` in `code-block`
 - fixed an issue for lists when list starts not at level 0 and when next list element is more than 1 level deeper